### PR TITLE
Add missing blank line above @desc in Kotlin files

### DIFF
--- a/src/main/kotlin/intro/IntLambda1.kt
+++ b/src/main/kotlin/intro/IntLambda1.kt
@@ -1,4 +1,5 @@
 package intro
+
 // @desc Follow the function calls step by step — what goes in, and what comes out?
 
 fun doubleIt1(i: Int): Int = i * 2

--- a/src/main/kotlin/intro/IntLambda2.kt
+++ b/src/main/kotlin/intro/IntLambda2.kt
@@ -1,4 +1,5 @@
 package intro
+
 // @desc A lambda stored in a variable works just like a regular function — trace the input through the math.
 
 val doubleIt2: (Int) -> Int = { i: Int -> i * 2 }

--- a/src/main/kotlin/intro/IntLambda3.kt
+++ b/src/main/kotlin/intro/IntLambda3.kt
@@ -1,4 +1,5 @@
 package intro
+
 // @desc Each call to **func3** uses a different function — check which one is passed and what it does to the input.
 
 val tripleIt3: (Int) -> Int = { i: Int -> i * 3 }

--- a/src/main/kotlin/intro/IntLambda4.kt
+++ b/src/main/kotlin/intro/IntLambda4.kt
@@ -1,4 +1,5 @@
 package intro
+
 // @desc The function returns *another function* — first figure out what the returned function does, then apply it.
 
 // Higher-order function as a return type

--- a/src/main/kotlin/intro/IntListLambda1.kt
+++ b/src/main/kotlin/intro/IntListLambda1.kt
@@ -1,4 +1,5 @@
 package intro
+
 // @desc The function applies each lambda in the list to the *same* input value and collects the results.
 
 val tripleIt4: (Int) -> Int = { i: Int -> i * 3 }

--- a/src/main/kotlin/intro/NoArgLambda1.kt
+++ b/src/main/kotlin/intro/NoArgLambda1.kt
@@ -1,4 +1,5 @@
 package intro
+
 // @desc Follow the chain of function calls — what value does each function return to its caller?
 
 fun constVal(): Int {

--- a/src/main/kotlin/intro/NoArgLambda2.kt
+++ b/src/main/kotlin/intro/NoArgLambda2.kt
@@ -1,4 +1,5 @@
 package intro
+
 // @desc A lambda assigned to a variable can be called with **.invoke()** or directly with parentheses.
 
 val constVal: () -> Int = { 4 }

--- a/src/main/kotlin/intro/NoArgLambda3.kt
+++ b/src/main/kotlin/intro/NoArgLambda3.kt
@@ -1,4 +1,5 @@
 package intro
+
 // @desc Each no-argument function returns a different constant — trace which one gets passed in each call.
 
 val constVal1: () -> Int = { 4 }

--- a/src/main/kotlin/intro/NoArgLambda4.kt
+++ b/src/main/kotlin/intro/NoArgLambda4.kt
@@ -1,4 +1,5 @@
 package intro
+
 // @desc The function returns a lambda that *captures* its parameter — trace what value the returned lambda holds.
 
 // Higher-order function as a return type

--- a/src/main/kotlin/intro/StringLambda1.kt
+++ b/src/main/kotlin/intro/StringLambda1.kt
@@ -1,4 +1,5 @@
 package intro
+
 // @desc **uppercase()** converts all characters to capitals — think about what happens when you join two copies.
 
 fun upperIt1(s: String): String = s.uppercase() + s.uppercase()

--- a/src/main/kotlin/intro/StringLambda2.kt
+++ b/src/main/kotlin/intro/StringLambda2.kt
@@ -1,4 +1,5 @@
 package intro
+
 // @desc A lambda assigned to a variable works like a regular function — trace what **.invoke()** does.
 
 val upperIt: (String) -> String = { s: String -> s.uppercase() + s.uppercase() }

--- a/src/main/kotlin/intro/StringLambda3.kt
+++ b/src/main/kotlin/intro/StringLambda3.kt
@@ -1,4 +1,5 @@
 package intro
+
 // @desc Each call passes a *different* function — check how many times each one applies **uppercase()**.
 
 val upperIt2: (String) -> String = { s: String -> s.uppercase() + s.uppercase() }

--- a/src/main/kotlin/lambda/StringLambda1.kt
+++ b/src/main/kotlin/lambda/StringLambda1.kt
@@ -1,4 +1,5 @@
 package lambda
+
 // @desc **mapIndexed** gives you both the index and the element — trace what gets combined at each position.
 
 fun List<String>.combine(): String = mapIndexed { i, s -> i.toString() + s }.joinToString(", ")

--- a/src/main/kotlin/lambda/StringLambda2.kt
+++ b/src/main/kotlin/lambda/StringLambda2.kt
@@ -1,4 +1,5 @@
 package lambda
+
 // @desc **chunked(1)** splits a string into single characters — then **mapIndexed** pairs each with its position.
 
 fun String.combine2(): String = chunked(1).mapIndexed { i, s -> i.toString() + s }.joinToString(", ")

--- a/src/main/kotlin/strings/FuncSum1.kt
+++ b/src/main/kotlin/strings/FuncSum1.kt
@@ -1,4 +1,5 @@
 package strings
+
 // @desc Each lambda in the list returns a number — **map** calls them all, then **sum()** adds the results.
 
 fun funcSum1(funcs: List<() -> Int>): Int =

--- a/src/main/kotlin/strings/FuncSum2.kt
+++ b/src/main/kotlin/strings/FuncSum2.kt
@@ -1,4 +1,5 @@
 package strings
+
 // @desc **sumOf** calls each lambda and adds up all the returned values in one step.
 
 fun funcSum2(funcs: List<() -> Int>): Int =

--- a/src/main/kotlin/strings/LambdaReturn1.kt
+++ b/src/main/kotlin/strings/LambdaReturn1.kt
@@ -1,4 +1,5 @@
 package strings
+
 // @desc The function returns a lambda — call **.invoke()** or **()** on it to get the actual string result.
 
 fun lambdaReturn1(word: String): () -> String = { word + word }

--- a/src/main/kotlin/strings/LambdaReturn2.kt
+++ b/src/main/kotlin/strings/LambdaReturn2.kt
@@ -1,4 +1,5 @@
 package strings
+
 // @desc The returned lambda captures the input string and computes its **length** when invoked.
 
 fun lambdaReturn2(word: String): () -> Int = { word.length }

--- a/src/main/kotlin/strings/StringElements1.kt
+++ b/src/main/kotlin/strings/StringElements1.kt
@@ -1,4 +1,5 @@
 package strings
+
 // @desc The list of indices tells you *which* characters to pick from the string — remember indexing starts at **0**.
 
 fun stringElements1(s: String, list: List<Int>): String =

--- a/src/main/kotlin/strings/StringElements2.kt
+++ b/src/main/kotlin/strings/StringElements2.kt
@@ -1,4 +1,5 @@
 package strings
+
 // @desc Each index is doubled *before* being used to look up a character — calculate the new positions first.
 
 fun stringElements2(s: String, list: List<Int>): String =

--- a/src/main/kotlin/strings/StringElements3.kt
+++ b/src/main/kotlin/strings/StringElements3.kt
@@ -1,4 +1,5 @@
 package strings
+
 // @desc Only the *even* indices survive the **filter** — figure out which ones pass before looking up characters.
 
 fun stringElements3(s: String, list: List<Int>): String =

--- a/src/main/kotlin/strings/StringElements4.kt
+++ b/src/main/kotlin/strings/StringElements4.kt
@@ -1,4 +1,5 @@
 package strings
+
 // @desc The indices are first doubled, then filtered to keep only even values — work through both steps.
 
 fun stringElements4(s: String, list: List<Int>): String =

--- a/src/main/kotlin/transformations/Chain1.kt
+++ b/src/main/kotlin/transformations/Chain1.kt
@@ -1,4 +1,5 @@
 package transformations
+
 // @desc Work through the chain left to right: uppercase each character, filter to keep only **A–F**, then lowercase.
 
 fun chain1(s: String): String =

--- a/src/main/kotlin/transformations/Chain2.kt
+++ b/src/main/kotlin/transformations/Chain2.kt
@@ -1,4 +1,5 @@
 package transformations
+
 // @desc Each character becomes its uppercase + lowercase pair — then only pairs containing **"a"** survive the filter.
 
 fun chain2(s: String): String =

--- a/src/main/kotlin/transformations/Filter1.kt
+++ b/src/main/kotlin/transformations/Filter1.kt
@@ -1,4 +1,5 @@
 package transformations
+
 // @desc **filter** keeps only the elements that pass the test — check each number from **0** to **i**.
 
 val isEven: (Int) -> Boolean = { i: Int -> i % 2 == 0 }

--- a/src/main/kotlin/transformations/Filter2.kt
+++ b/src/main/kotlin/transformations/Filter2.kt
@@ -1,4 +1,5 @@
 package transformations
+
 // @desc **filter** keeps strings that match the condition — test each string in the list against the predicate.
 
 val inRange1: (String) -> Boolean = { s: String -> s.startsWith("H") }

--- a/src/main/kotlin/transformations/Map1.kt
+++ b/src/main/kotlin/transformations/Map1.kt
@@ -1,4 +1,5 @@
 package transformations
+
 // @desc **map** transforms every element in a range — apply the given function to each value from **0** to **i**.
 
 val doubleIt: (Int) -> Int = { i: Int -> i * 2 }

--- a/src/main/kotlin/transformations/Map2.kt
+++ b/src/main/kotlin/transformations/Map2.kt
@@ -1,4 +1,5 @@
 package transformations
+
 // @desc The function maps each number to a **true**/**false** value — check the condition for every element in the range.
 
 val isInRange1: (Int) -> Boolean = { i: Int -> i in 3..6 }

--- a/src/main/kotlin/transformations/MapFilter1.kt
+++ b/src/main/kotlin/transformations/MapFilter1.kt
@@ -1,4 +1,5 @@
 package transformations
+
 // @desc First **map** transforms each value, then **filter** keeps only those that pass the test — do both steps in order.
 
 fun filterMap2Long(mapFunc: (Int) -> Int, filterFunc: (Int) -> Boolean): List<Int> {


### PR DESCRIPTION
## Summary
- Adds a blank line between the `package` declaration and `// @desc` comment in all 29 Kotlin challenge files
- Ensures consistent formatting: one blank line above and below every `@desc` hint (Java files were already correct)

## Test plan
- [ ] Run `./gradlew --rerun-tasks check` to verify no test regressions
- [ ] Spot-check Kotlin challenge files for correct spacing

🤖 Generated with [Claude Code](https://claude.com/claude-code)