### PR TITLE
Update build configuration and refresh docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,10 +11,14 @@ This is a **ReadingBat content repository** — it defines Java and Kotlin progr
 ```bash
 ./gradlew build -x test       # Compile without tests
 ./gradlew --rerun-tasks check  # Run all tests
+./gradlew test --tests "ContentTests"          # Run a single test class
+./gradlew test -Dkotest.filter.tests="<name>"  # Filter Kotest cases by name
 ./gradlew run                  # Start the content server locally (port 8080)
 make tests                     # Shortcut for running tests
 make build                     # Shortcut for compile
 make cc                        # Continuous compilation (watches for changes)
+make uberjar                   # Build fat jar at build/libs/server.jar
+make uber                      # Build uberjar and run it
 make versioncheck              # Check for dependency updates
 ```
 
@@ -25,7 +29,7 @@ The project uses JVM toolchain 17 and Kotest with JUnit Platform.
 ### Content Definition (DSL)
 
 `src/main/kotlin/Content.kt` is the central file. It uses the `readingBatContent` DSL to declare all challenges organized by language, groups, and individual challenges. The DSL references:
-- A `repo` source — `GitHubRepo` in production, `FileSystemSource("./")` for local dev (controlled by `isProduction()`)
+- A `repo` source — `GitHubRepo` in production, `FileSystemSource("./")` for local dev (controlled by `isProduction()`). Local dev reads challenge files directly from disk, so edits are picked up on reload without a rebuild.
 - `java { }` and `kotlin { }` blocks that define language sections
 - `group()` blocks with `packageName`, `description`, and challenge declarations
 - Challenges can be added individually via `challenge("ClassName")` or in bulk via `includeFiles` / `includeFilesWithType` glob patterns

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
+.PHONY: default clean build tests uberjar uber cc run heroku logs versioncheck upgrade-wrapper
+
 default: versioncheck
 
 clean:
 	./gradlew clean
 
-compile:
-	./gradlew build -x test
-
-build: compile
+build:
+	./gradlew build -xtest
 
 tests:
 	./gradlew --rerun-tasks check
@@ -18,10 +18,16 @@ uber: uberjar
 	java -jar build/libs/server.jar
 
 cc:
-	./gradlew build --continuous -x test
+	./gradlew build --continuous -xtest
 
 run:
 	./gradlew run
+
+heroku:
+	git push heroku master
+
+logs:
+	heroku logs --tail
 
 versioncheck:
 	./gradlew dependencyUpdates

--- a/README.md
+++ b/README.md
@@ -7,10 +7,15 @@ Java and Kotlin programming challenges for the [ReadingBat](https://github.com/r
 Requires JDK 17+.
 
 ```bash
-./gradlew build -x test        # Compile
+./gradlew build -x test         # Compile
 ./gradlew run                   # Start the content server on http://localhost:8080
 ./gradlew --rerun-tasks check   # Run all tests
+./gradlew test --tests "ContentTests"           # Run a single test class
+./gradlew test -Dkotest.filter.tests="<name>"   # Filter Kotest cases by name
+make uberjar                    # Build fat jar at build/libs/server.jar
 ```
+
+When running locally, challenge files are loaded directly from disk (via `FileSystemSource`), so edits are picked up on reload without a rebuild. Production builds load content from this GitHub repository.
 
 ## Challenge Structure
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
   application
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.versions)
+  alias(libs.plugins.ktor.plugin)
 }
 
 // This is for ./gradlew run
@@ -11,27 +12,36 @@ application {
   mainClass = "ContentServerKt"
 }
 
-group = "com.pambrose.readingbat"
-version = "1.0.0"
-
-repositories {
-  google()
-  mavenCentral()
-}
+description = "ReadingBat Site"
 
 dependencies {
   implementation(libs.readingbat.core)
-  implementation(libs.common.utils.core)
+  implementation(libs.core.utils)
   implementation(libs.kotlin.logging)
 
-  testImplementation(libs.readingbat.kotest)
-  testImplementation(libs.kotest.runner)
-  testImplementation(libs.kotest.assertions)
-  testImplementation(libs.ktor.server.test)
+  testImplementation(libs.bundles.testing)
 }
 
 kotlin {
   jvmToolchain(17)
+}
+
+tasks.register("stage") {
+  dependsOn("clean", "build")
+}
+
+tasks.named("build") {
+  mustRunAfter("clean")
+}
+
+tasks.shadowJar {
+  archiveFileName.set("server.jar")
+  isZip64 = true
+  duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+  exclude("META-INF/*.SF")
+  exclude("META-INF/*.DSA")
+  exclude("META-INF/*.RSA")
+  exclude("LICENSE*")
 }
 
 tasks.test {
@@ -40,14 +50,6 @@ tasks.test {
   testLogging {
     events = setOf(TestLogEvent.PASSED, TestLogEvent.SKIPPED, TestLogEvent.FAILED)
     exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
-    showStandardStreams = true
+    showStandardStreams = false
   }
-}
-
-tasks.withType<Tar> {
-  duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-}
-
-tasks.withType<Zip> {
-  duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,7 @@
+group=com.readingbat
+version=1.0.0
+
 kotlin.code.style=official
-org.gradle.daemon=true
-org.gradle.configureondemand=true
 org.gradle.caching=true
+org.gradle.configuration-cache=false
+org.gradle.daemon=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,21 +2,33 @@
 kotest = "6.1.11"
 kotlin = "2.3.21"
 ktor = "3.4.3"
-logging = "8.0.01"
-readingbat = "3.1.4"
-utils = "2.8.1"
+logging = "8.0.02"
+readingbat = "3.1.5"
+utils = "2.8.2"
 versions = "0.54.0"
 
 [libraries]
-common-utils-core = { module = "com.pambrose.common-utils:core-utils", version.ref = "utils" }
-kotlin-logging = { group = "io.github.oshai", name = "kotlin-logging-jvm", version.ref = "logging" }
+core-utils = { module = "com.pambrose.common-utils:core-utils", version.ref = "utils" }
+kotlin-logging = { module = "io.github.oshai:kotlin-logging-jvm", version.ref = "logging" }
 readingbat-core = { module = "com.readingbat:readingbat-core", version.ref = "readingbat" }
 readingbat-kotest = { module = "com.readingbat:readingbat-kotest", version.ref = "readingbat" }
 
+# Test dependencies
 kotest-assertions = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
 kotest-runner = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
+ktor-server-config-yaml = { module = "io.ktor:ktor-server-config-yaml", version.ref = "ktor" }
 ktor-server-test = { module = "io.ktor:ktor-server-test-host", version.ref = "ktor" }
+
+[bundles]
+testing = [
+    "readingbat-kotest",
+    "ktor-server-config-yaml",
+    "ktor-server-test",
+    "kotest-assertions",
+    "kotest-runner",
+]
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+ktor-plugin = { id = "io.ktor.plugin", version.ref = "ktor" }
 versions = { id = "com.github.ben-manes.versions", version.ref = "versions" }

--- a/llms.txt
+++ b/llms.txt
@@ -21,3 +21,20 @@ Each challenge is a standalone source file. The `main()` function prints expecte
 - Kotlin/JVM 17, Gradle (Kotlin DSL)
 - readingbat-core (platform library, from JitPack)
 - Kotest + Ktor test host (testing)
+
+## Common Commands
+
+- `./gradlew build -x test` — compile without tests
+- `./gradlew --rerun-tasks check` — run all tests
+- `./gradlew test --tests "ContentTests"` — run a single test class
+- `./gradlew test -Dkotest.filter.tests="<name>"` — filter Kotest cases by name
+- `./gradlew run` — start the content server on http://localhost:8080
+- `make uberjar` — build fat jar at `build/libs/server.jar`
+- `make uber` — build uberjar and run it
+- `make versioncheck` — check for dependency updates
+
+## Local vs Production
+
+The DSL in `Content.kt` swaps the `repo` source based on `isProduction()`:
+- Local dev uses `FileSystemSource("./")` — challenge files load directly from disk, so edits are picked up on reload without a rebuild.
+- Production uses `GitHubRepo` — content is fetched from the GitHub repository.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,19 @@
+pluginManagement {
+  repositories {
+    gradlePluginPortal()
+    mavenCentral()
+  }
+}
+
+plugins {
+  id("org.gradle.toolchains.foojay-resolver-convention").version("1.0.0")
+}
+
+dependencyResolutionManagement {
+  repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+  repositories {
+    mavenCentral()
+  }
+}
+
 rootProject.name = "readingbat-java-content"


### PR DESCRIPTION
## Summary

**Build**
- Add `ktor` plugin and `shadowJar` configuration so `make uberjar` produces `build/libs/server.jar`
- Consolidate plugin/dependency repositories in `settings.gradle.kts` (FAIL_ON_PROJECT_REPOS, foojay toolchain resolver)
- Bundle test dependencies under `libs.bundles.testing`; rename `common-utils-core` -> `core-utils`
- Bump `readingbat` 3.1.4 -> 3.1.5, `utils` 2.8.1 -> 2.8.2, `kotlin-logging` 8.0.01 -> 8.0.02
- Move `group`/`version` to `gradle.properties`; disable configuration cache
- Makefile: add `heroku` / `logs` targets, declare `.PHONY`, tidy flags

**Docs**
- `CLAUDE.md`, `README.md`, `llms.txt`: document single-test commands, `make uberjar` / `make uber` shortcuts, and the local-vs-production content loading behavior (`FileSystemSource` vs `GitHubRepo`)

## Test plan

- [ ] `./gradlew build -x test` succeeds
- [ ] `./gradlew --rerun-tasks check` passes
- [ ] `make uberjar` produces a runnable `build/libs/server.jar`
- [ ] `./gradlew run` starts the local content server on :8080

🤖 Generated with [Claude Code](https://claude.com/claude-code)