### PR TITLE
Centralize gradle and jvm versions in libs.versions.toml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 .PHONY: default clean build tests uberjar uber cc run heroku logs versioncheck upgrade-wrapper
 
+GRADLE_VERSION := $(shell grep '^gradle = ' gradle/libs.versions.toml | cut -d'"' -f2)
+
 default: versioncheck
 
 clean:
@@ -33,4 +35,4 @@ versioncheck:
 	./gradlew dependencyUpdates
 
 upgrade-wrapper:
-	./gradlew wrapper --gradle-version=9.5.0 --distribution-type=bin
+	./gradlew wrapper --gradle-version=$(GRADLE_VERSION) --distribution-type=bin

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
 }
 
 kotlin {
-  jvmToolchain(17)
+  jvmToolchain(libs.versions.jvm.get().toInt())
 }
 
 tasks.register("stage") {
@@ -38,10 +38,7 @@ tasks.shadowJar {
   archiveFileName.set("server.jar")
   isZip64 = true
   duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-  exclude("META-INF/*.SF")
-  exclude("META-INF/*.DSA")
-  exclude("META-INF/*.RSA")
-  exclude("LICENSE*")
+  listOf("META-INF/*.SF", "META-INF/*.DSA", "META-INF/*.RSA", "LICENSE*").forEach(::exclude)
 }
 
 tasks.test {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,6 @@
 [versions]
+gradle = "9.5.0"
+jvm = "17"
 kotest = "6.1.11"
 kotlin = "2.3.21"
 ktor = "3.4.3"


### PR DESCRIPTION
## Summary
- Move the gradle wrapper version (`9.5.0`) and JVM toolchain version (`17`) into `gradle/libs.versions.toml` so all version pins live in one place.
- `build.gradle.kts` reads the JVM version via `libs.versions.jvm.get().toInt()`.
- `Makefile` derives `GRADLE_VERSION` from `libs.versions.toml` and uses it in `upgrade-wrapper`.
- Collapse the four `shadowJar` `exclude()` calls into a single list.

## Test plan
- [x] `./gradlew help` parses the build script cleanly
- [x] `make -n upgrade-wrapper` expands to `./gradlew wrapper --gradle-version=9.5.0 --distribution-type=bin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)