### PR TITLE
Add CI workflow to run tests and lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Lint (kotlinter + detekt)
+        run: ./gradlew lintKotlin detekt
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Run tests
+        run: ./gradlew --rerun-tasks check -x lintKotlin -x detekt


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` with two parallel jobs triggered on push to `master` and on pull requests:
  - **lint** — runs `./gradlew lintKotlin detekt`
  - **test** — runs `./gradlew --rerun-tasks check -x lintKotlin -x detekt`
- Uses Temurin JDK 17 (matches `jvm = "17"` in `libs.versions.toml`) and `gradle/actions/setup-gradle@v4` for wrapper + dependency caching.
- A concurrency group cancels superseded runs on the same ref.

## Test plan

- [ ] Workflow appears under the Actions tab after this PR is opened
- [ ] Both `lint` and `test` jobs pass on this PR
- [ ] A subsequent push to the branch cancels the previous in-flight run

🤖 Generated with [Claude Code](https://claude.com/claude-code)